### PR TITLE
feature/Added codable device GET endpoints for iOS

### DIFF
--- a/app/devices/index.js
+++ b/app/devices/index.js
@@ -30,6 +30,24 @@ app.get('/', (req, res) => {
   });
 });
 
+app.get('/codable/', (req, res) => {
+  const devicesRef = dbref.child('Devices');
+  devicesRef.on('value', function (snapshot) {
+      let deviceList = [];
+      snapshot.forEach(function(childSnapshot) {
+          let childKey = childSnapshot.key;
+          let item = {
+              id: childKey,
+              name: childSnapshot.child('name').val(),
+              room_id: childSnapshot.child('room_id').val(),
+              value: childSnapshot.child('value').val()
+          };
+          deviceList.push(item)
+      });
+    return res.status(200).json(deviceList)
+  })
+});
+
 /** 
  * With URL parameters:
  * Send a POST request such as

--- a/app/rooms/index.js
+++ b/app/rooms/index.js
@@ -14,6 +14,7 @@ app.use(cookieParser);
 app.use(authMiddleware);
 app.get('/', (req, res) => getRoomsFromDatabase(res));
 app.get('/:id', (req, res) => getRoomDevices(req.params.id, req, res));
+app.get('/codable/:id', (req, res) => getRoomDevicesIos(req, res));
 
 const getRoomsFromDatabase = (res) => {
   const roomsRef = dbref.child('Rooms');
@@ -28,6 +29,25 @@ const getRoomDevices = (id, req, res) => {
   devicesRef.orderByChild('room_id').equalTo(req.params.id).on('value', function (snapshot) {
     return res.status(200).json(snapshot.val());
   });
+};
+
+const getRoomDevicesIos = (req, res) => {
+    const devicesRef = dbref.child('Devices');
+    const roomId = req.params.id;
+        devicesRef.orderByChild('room_id').equalTo(roomId).on('value', function (snapshot) {
+            let deviceList = [];
+            snapshot.forEach(function(childSnapshot) {
+                let childKey = childSnapshot.key;
+                let item = {
+                    id: childKey,
+                    name: childSnapshot.child('name').val(),
+                    room_id: childSnapshot.child('room_id').val(),
+                    value: childSnapshot.child('value').val()
+                };
+                deviceList.push(item)
+            });
+        return res.status(200).json(deviceList);
+    });
 };
 
 module.exports.rooms = functions.region('europe-west1').https.onRequest(app);


### PR DESCRIPTION
Endpoints added:

base-url/devices/codable/
	- returns array of all devices

base-url/rooms/codable/:id/
	- returns array of all devices in specified room

Return differs in structure to regular get endpoints
as the keys are within each object.

eg.
{
        "id": "HrWTumcyQgNbcai78KAv",
        "name": "lamp outside",
        "value": "true"
}

instead of:
    "HrWTumcyQgNbcai78KAv": {
        "name": "lamp outside",
        "room_id": "xXKPpHKTbMWCXDluthqz",
        "value": "true"
    }
